### PR TITLE
remove x_data argument from FABC class definition

### DIFF
--- a/src/ramanspy/preprocessing/baseline.py
+++ b/src/ramanspy/preprocessing/baseline.py
@@ -401,5 +401,5 @@ class FABC(PybaselinesCorrector):
     ----------
     Cobas, J.C., Bernstein, M.A., Martín-Pastor, M. and Tahoces, P.G., 2006. A new general-purpose fully automatic baseline-correction procedure for 1D and 2D NMR data. Journal of Magnetic Resonance, 183(1), pp.145-151.
     """
-    def __init__(self, *, lam=1000000.0, scale=None, num_std=3.0, diff_order=2, min_length=2, weights=None, weights_as_mask=False, x_data=None, **pad_kwargs):
-        super().__init__(pybaselines.classification.fabc, lam=lam, scale=scale, num_std=num_std, diff_order=diff_order, min_length=min_length, weights=weights, weights_as_mask=weights_as_mask, x_data=x_data, **pad_kwargs)
+    def __init__(self, *, lam=1000000.0, scale=None, num_std=3.0, diff_order=2, min_length=2, weights=None, weights_as_mask=False, **pad_kwargs):
+        super().__init__(pybaselines.classification.fabc, lam=lam, scale=scale, num_std=num_std, diff_order=diff_order, min_length=min_length, weights=weights, weights_as_mask=weights_as_mask, **pad_kwargs)


### PR DESCRIPTION
in the FABC baseline correction object there is an x_data input argument. however this conflicts with the x_data argument supplied to np.apply_along_axis baseline.py L33 and this causes `TypeError numpy.apply_along_axis() got mulitple values for the keyword argument 'x_data'`

none of the other baseline classes include x_data in the class definition since it is in the base class, so i removed this input argument from FABC.

python 3.11
ramanspy 0.2.10

how to recreate the issue:
```
import ramanspy as rp
import numpy as np
s = rp.Spectrum(np.random.rand(1000), np.linspace(300, 2000, 1000))
s2 = rp.preprocessing.baseline.FABC().apply(s)
```
output 

`TypeError numpy.apply_along_axis() got mulitple values for the keyword argument 'x_data'`