### PR TITLE
Documentation Update: Notice about Volumetric Cells dataset

### DIFF
--- a/src/ramanspy/datasets.py
+++ b/src/ramanspy/datasets.py
@@ -295,7 +295,8 @@ def volumetric_cells(cell_type='THP-1', folder=None) -> List[core.SpectralVolume
 
     Data from `Kallepitis et al. (2017) <https://www.nature.com/articles/ncomms14843>`_.
 
-    Must be downloaded first. Provided by authors on `Zenodo <https://zenodo.org/record/256329#.Y7wpc3bP1D_>`_.
+    Must be downloaded and converted first. Provided by authors on `Zenodo <https://zenodo.org/record/256329#.Y7wpc3bP1D_>`_. 
+    The data is in the .wip format which RamanSPy cannot at this moment parse, conversion to .mat requires Witec Software Suite. 
 
     Parameters
     ----------


### PR DESCRIPTION
In reference to [Issue 5](https://github.com/barahona-research-group/RamanSPy/issues/5), I have updated the documentation to include a notice that the data needs to be converted before use. 