### PR TITLE
Access fitted scikit model in decompose analysis

### DIFF
--- a/src/ramanspy/analysis/decompose.py
+++ b/src/ramanspy/analysis/decompose.py
@@ -67,7 +67,7 @@ def scikit_learn_wrapper(scikit_learn_model):
     def wrap(data, *args, **kwargs):
         model = scikit_learn_model(*args, **kwargs)
         spectra_transformed = model.fit_transform(data)
-
+        wrap.fitted_model = model
         return spectra_transformed, model.components_
 
     return wrap


### PR DESCRIPTION
Update to decompose to allow access to the fitted model (e.g., pca.method.model_fitted.explained_variance_ratio_)

Now you can run:
pca = rp.analysis.decompose.PCA(n_components=6)
pca_loadings, pca_components = pca.apply(spectral_data_preprocessed)
explained_variance_ratio = pca.method.model_fitted.explained_variance_ratio_