### PR TITLE
Added functionality for WITec line scans and time series

### DIFF
--- a/src/ramanspy/load.py
+++ b/src/ramanspy/load.py
@@ -101,8 +101,13 @@ def witec(
 
     elif len(spectral_data.shape) == 2:
         imagesize = get_value(matlab_dict, 'imagesize')
-        spectral_data = spectral_data.reshape(imagesize[1], imagesize[0], -1).transpose(1, 0, 2)
 
+        if imagesize.size > 0:  # i.e. 2D scan
+            spectral_data = spectral_data.reshape(imagesize[1], imagesize[0], -1).transpose(1, 0, 2)
+        
+        else:  # i.e. line scan or timeseries
+            spectral_data = spectral_data[np.newaxis, :]
+            
         obj = core.SpectralImage(spectral_data, shift_values)
 
     else:


### PR DESCRIPTION
## Added functionality for WITec line scans and time series

### Description
This PR introduces new functionality to support the loading of WITec line scans and time series data. It includes the implementation of parsing and handling routines specific to WITec line scan data formats. The line scan data is parsed into an `rp.SpectralImage` object with shape `(1, N)`, making it compatible with the rest of the existing spectral data processing pipeline.

TODO:
- [ ] Update documentation

### Linked Issue
See issue #32 for context and data samples for testing.